### PR TITLE
GeoNodeSource: set restrictedExtent with maxExtent

### DIFF
--- a/src/script/plugins/GeoNodeSource.js
+++ b/src/script/plugins/GeoNodeSource.js
@@ -102,7 +102,8 @@ gxp.plugins.GeoNodeSource = Ext.extend(gxp.plugins.WMSSource, {
                     config.title,
                     config.url,
                     {
-                        isBaseLayer: false
+                        isBaseLayer: false,
+                        restrictedExtent: maxExtent
                     }
                 );
             }else{
@@ -144,9 +145,9 @@ gxp.plugins.GeoNodeSource = Ext.extend(gxp.plugins.WMSSource, {
                     layer.attributes = config.attributes;
                 }
             };
-            
 
-            
+
+
 
 
             // data for the new record


### PR DESCRIPTION
When the layer isn't local,  the `restrictedExtent` must be set with `maxExtent` value to enable the zoom to extent in the boundaries of the layer.